### PR TITLE
Remove vglEnd usage.

### DIFF
--- a/src/video/vita/SDL_vitagles_vgl.c
+++ b/src/video/vita/SDL_vitagles_vgl.c
@@ -65,7 +65,6 @@ VITA_GLES_UnloadLibrary(_THIS)
     if (vgl_initialized)
     {
         vgl_initialized = 0;
-        vglEnd();
     }
     _this->gl_config.driver_loaded = 0;
 }


### PR DESCRIPTION
I've removed vglEnd from vitaGL entirely since incomplete and pointless to have (it's just easier to reboot the app with a different init setup if that's the result one wants to achieve).