### PR TITLE
Update for latest vitaGL support.

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -28,6 +28,11 @@
 #include "../../video/SDL_blit.h"
 #include "SDL_shaders_gles2.h"
 
+#if defined(SDL_VIDEO_VITA_VGL)
+#define GL_CG_VERTEX_SHADER_EXT 0x890E
+#define GL_CG_FRAGMENT_SHADER_EXT 0x890F
+#endif
+
 /* WebGL doesn't offer client-side arrays, so use Vertex Buffer Objects
    on Emscripten, which converts GLES2 into WebGL calls.
    In all other cases, attempt to use client-side arrays, as they tend to
@@ -495,9 +500,6 @@ GLES2_CacheShader(GLES2_RenderData *data, GLES2_ShaderType type, GLenum shader_t
     GLuint id;
     GLint compileSuccessful = GL_FALSE;
     const char *shader_src = (char *)GLES2_GetShader(type);
-#if defined(SDL_VIDEO_VITA_VGL)
-	char *has_glsl_translator = SDL_getenv("VITA_USE_GLSL_TRANSLATOR");
-#endif
 
     if (!shader_src) {
         SDL_SetError("No shader src");
@@ -505,13 +507,14 @@ GLES2_CacheShader(GLES2_RenderData *data, GLES2_ShaderType type, GLenum shader_t
     }
 
     /* Compile */
-    id = data->glCreateShader(shader_type);
 #if defined(SDL_VIDEO_VITA_VGL)
-	if (has_glsl_translator)
-		vglCgShaderSource(id, 1, &shader_src, NULL);
+	if (shader_type == GL_VERTEX_SHADER)
+		shader_type = GL_CG_VERTEX_SHADER_EXT;
 	else
+		shader_type = GL_CG_FRAGMENT_SHADER_EXT;
 #endif
-		data->glShaderSource(id, 1, &shader_src, NULL);
+    id = data->glCreateShader(shader_type);
+	data->glShaderSource(id, 1, &shader_src, NULL);
     data->glCompileShader(id);
     data->glGetShaderiv(id, GL_COMPILE_STATUS, &compileSuccessful);
 


### PR DESCRIPTION
vglCgShderSource has been removed in favour of the official GL_EXT_cg_shader extension. This commit adjusts the render path to follow this extension standards.