### PR TITLE
Move libime work buffer outside of stack.

### DIFF
--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -60,6 +60,7 @@
 
 SDL_Window *Vita_Window;
 SceWChar16 libime_out[SCE_IME_MAX_PREEDIT_LENGTH + SCE_IME_MAX_TEXT_LENGTH + 1];
+SceUInt32 libime_work[SCE_IME_WORK_BUFFER_SIZE / sizeof(SceInt32)];
 char libime_initval[8] = { 1 };
 SceImeCaret caret_rev;
 
@@ -493,7 +494,6 @@ void VITA_ShowScreenKeyboard(_THIS, SDL_Window *window)
 {
     SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
     SceInt32 res;
-    SceUInt32 libime_work[SCE_IME_WORK_BUFFER_SIZE / sizeof(SceInt32)];
     SceImeParam param;
 
     sceImeParamInit(&param);


### PR DESCRIPTION
workbuffer must persist. With current implementation it was randomly causing prefetch aborts.

```=== THREADS ===
    SceCommonDialogWorker
        ID: 0x400200fb
        Stop reason: 0x0 (No reason)
        Status: 0x8 (Waiting)
        PC: 0xe0009614 (SceLibKernel@1 + 0x6304)
    pthread
        ID: 0x400b0167
        Stop reason: 0x0 (No reason)
        Status: 0x8 (Waiting)
        PC: 0x8134f288 (ut99@1 + 0x2d2288)
    SDLAudioP2
        ID: 0x400b016d
        Stop reason: 0x0 (No reason)
        Status: 0x8 (Waiting)
        PC: 0x8134e618 (ut99@1 + 0x2d1618)
    vitaGL Garbage Collector
        ID: 0x40010193
        Stop reason: 0x0 (No reason)
        Status: 0x8 (Waiting)
        PC: 0xe0009614 (SceLibKernel@1 + 0x6304)
    SceGxmDisplayQueue
        ID: 0x4001019f
        Stop reason: 0x0 (No reason)
        Status: 0x8 (Waiting)
        PC: 0x8134e7b8 (ut99@1 + 0x2d17b8)
    pthread
        ID: 0x400101bb
        Stop reason: 0x30003 (Prefetch abort exception)
        Status: 0x1 (Running)
        PC: 0x4
        LR: 0x8147dbc3 (SceIme@1 + 0x1703)

=== THREAD "pthread" <0x400101bb> CRASHED (Prefetch abort exception) ===

DISASSEMBLY AROUND LR: 0x8147dbc2 (Thumb):
←[0mm
←[0mm810016f2 <_start+0x16>:
←[0mm810016f2:  53a0            strh    r0, [r4, r6]
←[0mm810016f4:  2501            movs    r5, #1
←[0mm810016f6:  f2c8 132e       movt    r3, #33070      ; 0x812e
←[0mm810016fa:  9300            str     r3, [sp, #0]
←[0mm810016fc:  e00b            b.n     81001716 <_start+0x3a>
←[0mm810016fe:  1938            adds    r0, r7, r4
←[0mm81001700:  1b31            subs    r1, r6, r4
 !!!←[0m                f84d 0025       str.w   r0, [sp, r5, lsl #2]
←[0mm81001706:  3501            adds    r5, #1
←[0mm81001708:  f2c0 f874       bl      812c17f4 <strnlen>
←[0mm8100170c:  2d1f            cmp     r5, #31
←[0mm8100170e:  f104 0401       add.w   r4, r4, #1
←[90m←[0m
REGISTERS:
    R0: 0x991f4428
    R1: 0x96efd7e8
    R2: 0x6
    R3: 0x0
    R4: 0x1
    R5: 0x96ef8988
    R6: 0x96ef8888
    R7: 0x96ef8888
    R8: 0x96ef88cc
    R9: 0x82194748
    R10: 0xe0015214
    R11: 0x96efd930
    R12: 0x0
    SP: 0x96efd6d0
    PC: 0x4
    LR: 0x8147dbc3 (SceIme@1 + 0x1703)